### PR TITLE
Bump version to 0.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Install Rust
       uses: hecrj/setup-rust-action@v1
       with:
-        rust-version: 1.65
+        rust-version: 1.69
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.0] - 2023-07-27
 
 ### Changed
 
@@ -225,6 +225,7 @@ without relying on the content of the response.
 
 - `send_frame` and `recv_frame` to send and receive length-delimited frames.
 
+[0.9.0]: https://github.com/petabi/oinq/compare/0.8.2...0.9.0
 [0.8.2]: https://github.com/petabi/oinq/compare/0.8.1...0.8.2
 [0.8.1]: https://github.com/petabi/oinq/compare/0.8.0...0.8.1
 [0.8.0]: https://github.com/petabi/oinq/compare/0.7.1...0.8.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "oinq"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.69"
 description = "The inter-agent communication protocol in the REview ecosystem"
 readme = "README.md"
 homepage = "https://github.com/petabi/oinq"


### PR DESCRIPTION
Bump version to 0.9.0
- rust version update from 1.65 to 1.69 in `ci.yml` and `Cargo.toml`