### PR TITLE
Support port numbers and protocols in filter rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `request::Handler::update_traffic_filter_rules` takes a slice of `(IpNet,
+  Option<Vec<u16>>, Option<Vec<u16>>)`, instead of `IpNet`, to support port
+  numbers and protocols.
+
 ## [0.10.0] - 2024-02-23
 
 ### Changed
@@ -255,6 +263,7 @@ without relying on the content of the response.
 
 - `send_frame` and `recv_frame` to send and receive length-delimited frames.
 
+[Unreleased]: https://github.com/petabi/oinq/compare/0.10.0...main
 [0.10.0]: https://github.com/petabi/oinq/compare/0.9.3...0.10.0
 [0.9.3]: https://github.com/petabi/oinq/compare/0.9.2...0.9.3
 [0.9.2]: https://github.com/petabi/oinq/compare/0.9.1...0.9.2


### PR DESCRIPTION
`request::Handler::update_traffic_filter_rules` takes a slice of `(IpNet, Option<Vec<u16>>, Option<Vec<u16>>)`, instead of `IpNet`, to support port numbers and protocols.