### PR TITLE
Simplify `SendError::MessageTooLarge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- `SendError::MessageTooLarge` no longer contains the underlying error,
+  `std::num::TryFromIntError`, since it does not provide any useful information.
+
 ### Removed
 
 - `RequestCode::Forward` and `message::send_forward_request`, since forwarding

--- a/src/message.rs
+++ b/src/message.rs
@@ -60,7 +60,7 @@ impl From<SendError> for HandshakeError {
     fn from(e: SendError) -> Self {
         match e {
             SendError::SerializationFailure(e) => HandshakeError::SerializationFailure(e),
-            SendError::MessageTooLarge(_) => HandshakeError::MessageTooLarge,
+            SendError::MessageTooLarge => HandshakeError::MessageTooLarge,
             SendError::WriteError(e) => HandshakeError::WriteError(e),
         }
     }


### PR DESCRIPTION
This commit refactors the `SendError::MessageTooLarge` variant to no longer carry the `std::num::TryFromIntError` as its inner error. This change stems from the observation that the underlying `TryFromIntError` did not provide additional useful context to the error handling process.