### PR TITLE
Remove `HandshakeError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `RequestCode::Forward` and `message::send_forward_request`, since forwarding
   messages between agents is no longer supported.
-- `client_handshake`, `server_handshake`, and `AgentInfo`. These belong to the
-  `review-protocol` crate.
+- `client_handshake`, `server_handshake`, `HandshakeError`, and `AgentInfo`.
+  These belong to the `review-protocol` crate.
 
 ## [0.11.0] - 2024-03-25
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oinq"
-version = "0.11.0"
+version = "0.12.0-alpha.1"
 edition = "2021"
 rust-version = "1.69"
 description = "The inter-agent communication protocol in the REview ecosystem"


### PR DESCRIPTION
`HandshakeError` will be provided by review-protocol.

This is a part of #60.