### PR TITLE
Add `parse_args`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `request::parse_args` and `request::send_response` to help implementing
+  request handlers.
+
 ### Changed
 
 - `SendError::MessageTooLarge` no longer contains the underlying error,


### PR DESCRIPTION
This combines the argument parsing logic from the request handler into a new function, in order to reduce the redundancy of the argument parsing logic.

It is declared as `pub` so that it can be used by crates implementing custom request handlers.