### PR TITLE
Replace custom `RecvError` with `std::io::Error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `frame::recv`, `frame::recv_raw`, `message::recv_request_raw`, and
+  `request::parse_args` returns `io::Error` instead of `RecvError`.
+
+### Removed
+
+- `RecvError` is no longer used. The read functions return `std::io::Error`
+  instead.
+
 ## [0.12.0] - 2024-04-04
 
 ### Added
@@ -287,6 +299,7 @@ without relying on the content of the response.
 
 - `send_frame` and `recv_frame` to send and receive length-delimited frames.
 
+[Unreleased]: https://github.com/petabi/oinq/compare/0.12.0...main
 [0.12.0]: https://github.com/petabi/oinq/compare/0.11.0...0.12.0
 [0.11.0]: https://github.com/petabi/oinq/compare/0.10.0...0.11.0
 [0.10.0]: https://github.com/petabi/oinq/compare/0.9.3...0.10.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ bincode = "1"
 futures = "0.3"
 num_enum = "0.7"
 quinn = "0.10"
+quinn-proto = "0.10"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 tokio = "1"


### PR DESCRIPTION
This commit simplifies error handling by replacing the custom `RecvError` with the standard `std::io::Error`. The changes affect functions involved in receiving and parsing data, specifically in the `frame` and `message` modules.