### PR TITLE
Use `io::Error` instead of `SendError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 
-- `RecvError` is no longer used. The read functions return `std::io::Error`
-  instead.
+- `RecvError` and `SendError` are no longer used. The recv/send functions return
+  `std::io::Error` instead.
 - Bump dependencies.
   - Update quinn to version 0.11.
   - Update rustls to version 0.23.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ num_enum = "0.7"
 quinn = "0.11"
 quinn-proto = "0.11"
 serde = { version = "1", features = ["derive"] }
-thiserror = "1"
 tokio = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
This PR refactors the error handling mechanism for the `send` functions, replacing the custom `SendError` type with the standard `io::Error`. This change simplifies the error management and leverages the comprehensive error handling provided by the `io::Error` type.