### PR TITLE
Use LazyLock to replace lazy-static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ tokio = "1"
 
 [dev-dependencies]
 futures = "0.3"
-lazy_static = "1"
 quinn = { version = "0.11", features = ["ring"] }
 rcgen = "0.13"
 rustls = { version = "0.23", default-features = false, features = [

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,7 @@
 //! Shared test code
 
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
+
 use quinn::{Connection, RecvStream, SendStream};
 use tokio::sync::Mutex;
 
@@ -15,9 +16,7 @@ pub(crate) struct Endpoint {
     pub(crate) recv: RecvStream,
 }
 
-lazy_static! {
-    pub(crate) static ref TOKEN: Mutex<u32> = Mutex::new(0);
-}
+pub(crate) static TOKEN: LazyLock<Mutex<u32>> = LazyLock::new(|| Mutex::new(0));
 
 /// Creates a bidirectional channel, returning server's send and receive and
 /// client's send and receive streams.


### PR DESCRIPTION
This removes lazy-static from the dev-dependencies.

Close: #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the initialization logic for the `TOKEN` variable, enhancing clarity and thread safety.
  
- **Chores**
	- Removed the `lazy_static` dependency to streamline the development environment and reduce external dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->